### PR TITLE
Bug: Fix Dragged Card Visual Error

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -27,6 +27,7 @@ module.exports = {
     '@stylistic/jsx-indent': [2, 2],
     '@stylistic/quotes': ['error', 'single', { 'allowTemplateLiterals': true }],
     '@stylistic/semi': ['error', 'always', { 'omitLastInOneLineBlock': true}],
+    '@typescript-eslint/no-namespace': 'off',
   },
   'root': true,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "citadel",
       "version": "0.0.0",
       "dependencies": {
+        "@thisbeyond/solid-dnd": "^0.7.5",
         "solid-js": "^1.8.7"
       },
       "devDependencies": {
@@ -1537,6 +1538,18 @@
       },
       "peerDependencies": {
         "eslint": ">=8.40.0"
+      }
+    },
+    "node_modules/@thisbeyond/solid-dnd": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@thisbeyond/solid-dnd/-/solid-dnd-0.7.5.tgz",
+      "integrity": "sha512-DfI5ff+yYGpK9M21LhYwIPlbP2msKxN2ARwuu6GF8tT1GgNVDTI8VCQvH4TJFoVApP9d44izmAcTh/iTCH2UUw==",
+      "engines": {
+        "node": ">=18.0.0",
+        "pnpm": ">=8.6.0"
+      },
+      "peerDependencies": {
+        "solid-js": "^1.5"
       }
     },
     "node_modules/@types/babel__core": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "prepare": "husky install"
   },
   "dependencies": {
+    "@thisbeyond/solid-dnd": "^0.7.5",
     "solid-js": "^1.8.7"
   },
   "devDependencies": {

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,5 +1,16 @@
+import 'solid-js';
 import { Tableau } from '@/features/card-game';
+import type { Droppable, Draggable } from '@/common/types';
 import './App.css';
+
+declare module 'solid-js' {
+  namespace JSX {
+    interface DirectiveFunctions {
+      droppable: Droppable;
+      draggable: Draggable;
+    }
+  }
+}
 
 function App() {
   return (

--- a/src/common/classes/Card.ts
+++ b/src/common/classes/Card.ts
@@ -2,11 +2,13 @@ import { CardValue, Suit } from '@/common/types';
 import cardImages from '@/assets/cards';
 
 export class Card {
+  id: string;
   suit: Suit;
   value: CardValue;
   image: string;
 
   constructor(suit: Suit, value: CardValue) {
+    this.id = `${suit}${value}`;
     this.suit = suit;
     this.value = value;
     this.image = this.getImage(suit, value);

--- a/src/common/types/dnd.ts
+++ b/src/common/types/dnd.ts
@@ -1,0 +1,26 @@
+import { Setter } from 'solid-js';
+
+interface Transform {
+  x: number;
+  y: number;
+}
+
+type Listeners = Record<
+  string,
+  (event: HTMLElementEventMap[keyof HTMLElementEventMap]) => void
+>;
+
+export interface Draggable {
+  (element: HTMLElement, accessor?: () => { skipTransform?: boolean }): void;
+  ref: Setter<HTMLElement | null>;
+  get isActiveDraggable(): boolean;
+  get dragActivators(): Listeners;
+  get transform(): Transform;
+}
+
+export interface Droppable {
+  (element: HTMLElement, accessor?: () => { skipTransform?: boolean }): void;
+  ref: Setter<HTMLElement | null>;
+  get isActiveDroppable(): boolean;
+  get transform(): Transform;
+}

--- a/src/common/types/index.ts
+++ b/src/common/types/index.ts
@@ -9,3 +9,5 @@ export interface Card {
   suit: Suit,
   image?: string,
 }
+
+export * from './dnd';

--- a/src/features/card-game/Card.css
+++ b/src/features/card-game/Card.css
@@ -1,7 +1,11 @@
 .card-game-card {
   position: absolute;
-  width: 100%;
   width: 100px;
+  height: 150px;
+}
+
+.card-game-card.dragging {
+  z-index: 1;
 }
 
 .card-game-card .card-image {

--- a/src/features/card-game/Card.tsx
+++ b/src/features/card-game/Card.tsx
@@ -1,23 +1,20 @@
 import { JSX } from 'solid-js';
-import { Draggable } from '@/features/common';
+import { createDraggable } from '@thisbeyond/solid-dnd';
 import type { CardProps } from './types';
 import './Card.css';
 
 export function Card(props: CardProps): JSX.Element {
+  // @ts-expect-error: Directive used below
+  const draggable = createDraggable(props.data.id);
+
   return (
-    <Draggable
-      isDraggable={props.isDraggable}
-      onDragStart={props.onDragStart}
-      onDragEnd={props.onDragEnd}
-    >
-      <div class="card-game-card" style={props.style}>
-        <img
-          alt={`${props.data.value} of ${props.data.suit}`}
-          class="card-image"
-          src={props.data.image}
-          draggable="false"
-        />
-      </div>
-    </Draggable>
+    <div use:draggable class="card-game-card" style={props.style}>
+      <img
+        alt={`${props.data.value} of ${props.data.suit}`}
+        class="card-image"
+        src={props.data.image}
+        draggable="false"
+      />
+    </div>
   );
 }

--- a/src/features/card-game/CardPile.tsx
+++ b/src/features/card-game/CardPile.tsx
@@ -1,6 +1,7 @@
 import { For } from 'solid-js';
 import { DIRECTION_LTR, DIRECTION_RTL } from '@/common/constants';
 import { CardPileProps } from './types';
+import { Droppable } from '@/features/common';
 import { Card } from '.';
 import './CardPile.css';
 
@@ -8,21 +9,21 @@ export function CardPile(props: CardPileProps) {
   const getOffset = (index: number) => `${index * 20}px`;
 
   return (
-    <div class={`card-game-card-pile ${props.direction}`}>
-      <For each={props.cards}>
-        {(item, index) => (
-          <Card
-            data={item}
-            isDraggable={index() === (props.cards.length - 1)}
-            onDragEnd={props.onDragEnd}
-            onDragStart={props.onDragStart(item)}
-            style={{
-              left: props.direction === DIRECTION_LTR ? getOffset(index()) : 'auto',
-              right: props.direction === DIRECTION_RTL ? getOffset(index()) : 'auto',
-            }}
-          />
-        )}
-      </For>
-    </div>
+    <Droppable id={props.id} type={props.type}>
+      <div class={`card-game-card-pile ${props.direction}`}>
+        <For each={props.cards}>
+          {(item, index) => (
+            <Card
+              data={item}
+              isDraggable={index() === (props.cards.length - 1)}
+              style={{
+                left: props.direction === DIRECTION_LTR ? getOffset(index()) : 'auto',
+                right: props.direction === DIRECTION_RTL ? getOffset(index()) : 'auto',
+              }}
+            />
+          )}
+        </For>
+      </div>
+    </Droppable>
   );
 }

--- a/src/features/card-game/CardPile.tsx
+++ b/src/features/card-game/CardPile.tsx
@@ -1,8 +1,8 @@
-import { For } from 'solid-js';
+import { For, Show } from 'solid-js';
 import { DIRECTION_LTR, DIRECTION_RTL } from '@/common/constants';
 import { CardPileProps } from './types';
 import { Droppable } from '@/features/common';
-import { Card } from '.';
+import { Card, EmptyCard } from '.';
 import './CardPile.css';
 
 export function CardPile(props: CardPileProps) {
@@ -13,14 +13,26 @@ export function CardPile(props: CardPileProps) {
       <div class={`card-game-card-pile ${props.direction}`}>
         <For each={props.cards}>
           {(item, index) => (
-            <Card
-              data={item}
-              isDraggable={index() === (props.cards.length - 1)}
-              style={{
-                left: props.direction === DIRECTION_LTR ? getOffset(index()) : 'auto',
-                right: props.direction === DIRECTION_RTL ? getOffset(index()) : 'auto',
-              }}
-            />
+            <Show
+              when={index() === (props.cards.length - 1)}
+              fallback={(
+                <EmptyCard
+                  data={item}
+                  style={{
+                    left: props.direction === DIRECTION_LTR ? getOffset(index()) : 'auto',
+                    right: props.direction === DIRECTION_RTL ? getOffset(index()) : 'auto',
+                  }}
+                />
+              )}
+            >
+              <Card
+                data={item}
+                style={{
+                  left: props.direction === DIRECTION_LTR ? getOffset(index()) : 'auto',
+                  right: props.direction === DIRECTION_RTL ? getOffset(index()) : 'auto',
+                }}
+              />
+            </Show>
           )}
         </For>
       </div>

--- a/src/features/card-game/EmptyCard.tsx
+++ b/src/features/card-game/EmptyCard.tsx
@@ -1,0 +1,16 @@
+import { JSX } from 'solid-js';
+import type { CardProps } from './types';
+import './Card.css';
+
+export function EmptyCard(props: CardProps): JSX.Element {
+  return (
+    <div class="card-game-card" style={props.style}>
+      <img
+        alt={`${props.data.value} of ${props.data.suit}`}
+        class="card-image"
+        src={props.data.image}
+        draggable="false"
+      />
+    </div>
+  );
+}

--- a/src/features/card-game/Foundation.tsx
+++ b/src/features/card-game/Foundation.tsx
@@ -12,7 +12,6 @@ export function Foundation(props: FoundationProps) {
           {item => (
             <Card
               data={item}
-              isDraggable={item.value !== 'Ace'}
             />
           )}
         </For>

--- a/src/features/card-game/Foundation.tsx
+++ b/src/features/card-game/Foundation.tsx
@@ -1,21 +1,22 @@
 import { For } from 'solid-js';
+import { Droppable } from '@/features/common';
 import { FoundationProps } from './types';
 import { Card } from '.';
 import './Foundation.css';
 
 export function Foundation(props: FoundationProps) {
   return (
-    <div class="card-game-foundation">
-      <For each={props.cards}>
-        {item => (
-          <Card
-            data={item}
-            isDraggable={item.value !== 'Ace'}
-            onDragEnd={props.onDragEnd}
-            onDragStart={props.onDragStart(item)}
-          />
-        )}
-      </For>
-    </div>
+    <Droppable id={props.id} type={props.type}>
+      <div class="card-game-foundation">
+        <For each={props.cards}>
+          {item => (
+            <Card
+              data={item}
+              isDraggable={item.value !== 'Ace'}
+            />
+          )}
+        </For>
+      </div>
+    </Droppable>
   );
 }

--- a/src/features/card-game/Tableau.tsx
+++ b/src/features/card-game/Tableau.tsx
@@ -1,10 +1,27 @@
 import { Accessor, Setter, createEffect, createSignal } from 'solid-js';
+import { DragDropProvider, DragDropSensors, DragEventHandler } from '@thisbeyond/solid-dnd';
 import { DIRECTION_LTR, DIRECTION_RTL } from '@/common/constants';
 import { Card } from '@/common/classes/Card';
-import { Droppable } from '@/features/common';
-import { CardPile, Foundation } from '.';
-import './Tableau.css';
 import { Deck } from '@/common/classes/Deck';
+import { CardPile, Foundation } from '.';
+import {
+  DROPPABLE_TYPE_CARDPILE,
+  DROPPABLE_TYPE_FOUNDATION,
+  CARD_PILE_1,
+  CARD_PILE_2,
+  CARD_PILE_3,
+  CARD_PILE_4,
+  CARD_PILE_5,
+  CARD_PILE_6,
+  CARD_PILE_7,
+  CARD_PILE_8,
+  FOUNDATION_PILE_1,
+  FOUNDATION_PILE_2,
+  FOUNDATION_PILE_3,
+  FOUNDATION_PILE_4,
+  FOUNDATION_PILES,
+} from './constants';
+import './Tableau.css';
 
 export function Tableau() {
   const [cardPile1, setCardPile1] = createSignal<Card[]>([]);
@@ -21,20 +38,41 @@ export function Tableau() {
   const [foundationPile3, setFoundationPile3] = createSignal<Card[]>([new Card('clubs', 'Ace')]);
   const [foundationPile4, setFoundationPile4] = createSignal<Card[]>([new Card('spades', 'Ace')]);
 
-  const lastCardAndSetter: () => [Card | undefined, Setter<Card[]>][] = () => [
-    [cardPile1()[cardPile1().length - 1], setCardPile1],
-    [cardPile2()[cardPile2().length - 1], setCardPile2],
-    [cardPile3()[cardPile3().length - 1], setCardPile3],
-    [cardPile4()[cardPile4().length - 1], setCardPile4],
-    [cardPile5()[cardPile5().length - 1], setCardPile5],
-    [cardPile6()[cardPile6().length - 1], setCardPile6],
-    [cardPile7()[cardPile7().length - 1], setCardPile7],
-    [cardPile8()[cardPile8().length - 1], setCardPile8],
-    [foundationPile1()[foundationPile1().length - 1], setFoundationPile1],
-    [foundationPile2()[foundationPile2().length - 1], setFoundationPile2],
-    [foundationPile3()[foundationPile3().length - 1], setFoundationPile3],
-    [foundationPile4()[foundationPile4().length - 1], setFoundationPile4],
-  ];
+
+  const [moveToPile, setMoveToPile] = createSignal<[Card | null, Setter<Card[]> | null, Setter<Card[]> | null]>([null, null, null]);
+
+  const addCard = (nextCard: Card) => (cards: Card[]) => [...cards, nextCard];
+  const lastCard = (cards: Accessor<Card[]>) => cards()[cards().length - 1];
+
+  const lastCardHash: () => Record<string, [Accessor<Card[]>, Setter<Card[]>]> = () => ({
+    [lastCard(cardPile1).id]: [cardPile1, setCardPile1],
+    [lastCard(cardPile2).id]: [cardPile2, setCardPile2],
+    [lastCard(cardPile3).id]: [cardPile3, setCardPile3],
+    [lastCard(cardPile4).id]: [cardPile4, setCardPile4],
+    [lastCard(cardPile5).id]: [cardPile5, setCardPile5],
+    [lastCard(cardPile6).id]: [cardPile6, setCardPile6],
+    [lastCard(cardPile7).id]: [cardPile7, setCardPile7],
+    [lastCard(cardPile8).id]: [cardPile8, setCardPile8],
+    [lastCard(foundationPile1).id]: [foundationPile1, setFoundationPile1],
+    [lastCard(foundationPile2).id]: [foundationPile2, setFoundationPile2],
+    [lastCard(foundationPile3).id]: [foundationPile3, setFoundationPile3],
+    [lastCard(foundationPile4).id]: [foundationPile4, setFoundationPile4],
+  });
+
+  const pilesHash: () => Record<string, [Accessor<Card[]>, Setter<Card[]>]> = () => ({
+    [CARD_PILE_1]: [cardPile1, setCardPile1],
+    [CARD_PILE_2]: [cardPile2, setCardPile2],
+    [CARD_PILE_3]: [cardPile3, setCardPile3],
+    [CARD_PILE_4]: [cardPile4, setCardPile4],
+    [CARD_PILE_5]: [cardPile5, setCardPile5],
+    [CARD_PILE_6]: [cardPile6, setCardPile6],
+    [CARD_PILE_7]: [cardPile7, setCardPile7],
+    [CARD_PILE_8]: [cardPile8, setCardPile8],
+    [FOUNDATION_PILE_1]: [foundationPile1, setFoundationPile1],
+    [FOUNDATION_PILE_2]: [foundationPile2, setFoundationPile2],
+    [FOUNDATION_PILE_3]: [foundationPile3, setFoundationPile3],
+    [FOUNDATION_PILE_4]: [foundationPile4, setFoundationPile4],
+  });
 
   const lastFoundationCardAndSetter: () => [Card, Setter<Card[]>][] = () => [
     [foundationPile1()[foundationPile1().length - 1], setFoundationPile1],
@@ -43,43 +81,34 @@ export function Tableau() {
     [foundationPile4()[foundationPile4().length - 1], setFoundationPile4],
   ];
 
-  const [draggedCard, setDraggedCard] = createSignal<null | Card>(null);
-  const [moveToPile, setMoveToPile] = createSignal<[Card | null, Setter<Card[]> | null, Setter<Card[]> | null]>([null, null, null]);
-  const [moveToFoundation, setMoveToFoundation] = createSignal<[Card | null, Setter<Card[]> | null, Setter<Card[]> | null]>([null, null, null]);
+  const dragEndHandler: DragEventHandler = ({ draggable, droppable }) => {
+    if (!draggable || !droppable) return;
 
-  const addCard = (nextCard: Card) => (cards: Card[]) => [...cards, nextCard];
+    draggable.node.classList.remove('dragging');
 
-  const dragStartHandler = (playingCard: Card) => () => {
-    setDraggedCard(playingCard);
-  };
+    const [originalPileGetter, originalPileSetter] = lastCardHash()[draggable.id] || [];
+    const [newPileGetter, newPileSetter] = pilesHash()[droppable.id] || [];
 
-  const dragEndHandler = () => {
-    setDraggedCard(null);
-  };
+    if (!originalPileGetter || !originalPileSetter || !newPileGetter || !newPileSetter) return;
 
-  const dropHandler = (cardPile: Accessor<Card[]>, cardPileSetter: Setter<Card[]>) => () => {
-    const [, setter] = lastCardAndSetter().find(([card]) => card === draggedCard()) || [];
-    const lastCard = cardPile()[cardPile().length - 1];
-    const card = draggedCard();
+    const card = lastCard(originalPileGetter);
+    const newPileLastCard = lastCard(newPileGetter);
 
-    if (setter && card && (lastCard === undefined || card.isOneLesser(lastCard))) {
-      setMoveToPile([draggedCard(), cardPileSetter, setter]);
-    }
-  };
-
-  const dropFoundationHandler = (cardPile: Accessor<Card[]>, cardPileSetter: Setter<Card[]>) => () => {
-    const [, setter] = lastCardAndSetter().find(([card]) => card === draggedCard()) || [];
-    const lastCard = cardPile()[cardPile().length - 1];
-    const card = draggedCard();
-
-    if (setter
+    if (
+      FOUNDATION_PILES.includes(String(droppable.id))
       && card !== null
-      && lastCard !== undefined
-      && lastCard.isOneLesser(card)
-      && lastCard.isSameSuit(card)
+      && newPileLastCard !== undefined
+      && newPileLastCard.isOneLesser(card)
+      && newPileLastCard.isSameSuit(card)
     ) {
-      setMoveToFoundation([draggedCard(), cardPileSetter, setter]);
+      setMoveToPile([card, newPileSetter, originalPileSetter]);
+    } else if (card && (newPileLastCard === undefined || card.isOneLesser(newPileLastCard))) {
+      setMoveToPile([card, newPileSetter, originalPileSetter]);
     }
+  };
+
+  const dragStartHandler: DragEventHandler = ({ draggable }) => {
+    draggable.node.classList.add('dragging');
   };
 
   createEffect(() => {
@@ -147,115 +176,85 @@ export function Tableau() {
   createEffect(() => {
     const [droppedCard, to, from] = moveToPile();
     if (droppedCard && from && to) {
-      from((cards: Card[]) => cards.slice(0, cards.length - 1));
+      from(cards => cards.slice(0, cards.length - 1));
       to(addCard(droppedCard));
       setMoveToPile([null, null, null]);
     }
   });
 
-  createEffect(() => {
-    const [droppedCard, to, from] = moveToFoundation();
-    if (droppedCard && from && to) {
-      from((cards: Card[]) => cards.slice(0, cards.length - 1));
-      to(addCard(droppedCard));
-      setMoveToFoundation([null, null, null]);
-    }
-  });
-
   return (
-    <div class="card-game-tableau">
-      <Droppable isDroppable onDrop={dropHandler(cardPile1, setCardPile1)}>
+    <DragDropProvider onDragEnd={dragEndHandler} onDragStart={dragStartHandler}>
+      <DragDropSensors />
+      <div class="card-game-tableau">
         <CardPile
           cards={cardPile1()}
           direction={DIRECTION_RTL}
-          onDragStart={dragStartHandler}
-          onDragEnd={dragEndHandler}
+          id={CARD_PILE_1}
+          type={DROPPABLE_TYPE_CARDPILE}
         />
-      </Droppable>
-      <Droppable isDroppable onDrop={dropFoundationHandler(foundationPile1, setFoundationPile1)}>
         <Foundation
           cards={foundationPile1()}
-          onDragStart={dragStartHandler}
-          onDragEnd={dragEndHandler}
+          id={FOUNDATION_PILE_1}
+          type={DROPPABLE_TYPE_FOUNDATION}
         />
-      </Droppable>
-      <Droppable isDroppable onDrop={dropHandler(cardPile2, setCardPile2)}>
-        <CardPile
-          cards={cardPile2()}
-          direction={DIRECTION_LTR}
-          onDragStart={dragStartHandler}
-          onDragEnd={dragEndHandler}
-        />
-      </Droppable>
-      <Droppable isDroppable onDrop={dropHandler(cardPile3, setCardPile3)}>
-        <CardPile
-          cards={cardPile3()}
-          direction={DIRECTION_RTL}
-          onDragStart={dragStartHandler}
-          onDragEnd={dragEndHandler}
-        />
-      </Droppable>
-      <Droppable isDroppable onDrop={dropFoundationHandler(foundationPile2, setFoundationPile2)}>
-        <Foundation
-          cards={foundationPile2()}
-          onDragStart={dragStartHandler}
-          onDragEnd={dragEndHandler}
-        />
-      </Droppable>
-      <Droppable isDroppable onDrop={dropHandler(cardPile4, setCardPile4)}>
-        <CardPile
-          cards={cardPile4()}
-          direction={DIRECTION_LTR}
-          onDragStart={dragStartHandler}
-          onDragEnd={dragEndHandler}
-        />
-      </Droppable>
-      <Droppable isDroppable onDrop={dropHandler(cardPile5, setCardPile5)}>
         <CardPile
           cards={cardPile5()}
+          direction={DIRECTION_LTR}
+          id={CARD_PILE_5}
+          type={DROPPABLE_TYPE_CARDPILE}
+        />
+        <CardPile
+          cards={cardPile2()}
           direction={DIRECTION_RTL}
-          onDragStart={dragStartHandler}
-          onDragEnd={dragEndHandler}
+          id={CARD_PILE_2}
+          type={DROPPABLE_TYPE_CARDPILE}
         />
-      </Droppable>
-      <Droppable isDroppable onDrop={dropFoundationHandler(foundationPile3, setFoundationPile3)}>
         <Foundation
-          cards={foundationPile3()}
-          onDragStart={dragStartHandler}
-          onDragEnd={dragEndHandler}
+          cards={foundationPile2()}
+          id={FOUNDATION_PILE_2}
+          type={DROPPABLE_TYPE_FOUNDATION}
         />
-      </Droppable>
-      <Droppable isDroppable onDrop={dropHandler(cardPile6, setCardPile6)}>
         <CardPile
           cards={cardPile6()}
           direction={DIRECTION_LTR}
-          onDragStart={dragStartHandler}
-          onDragEnd={dragEndHandler}
+          id={CARD_PILE_6}
+          type={DROPPABLE_TYPE_CARDPILE}
         />
-      </Droppable>
-      <Droppable isDroppable onDrop={dropHandler(cardPile7, setCardPile7)}>
+        <CardPile
+          cards={cardPile3()}
+          direction={DIRECTION_RTL}
+          id={CARD_PILE_3}
+          type={DROPPABLE_TYPE_CARDPILE}
+        />
+        <Foundation
+          cards={foundationPile3()}
+          id={FOUNDATION_PILE_3}
+          type={DROPPABLE_TYPE_FOUNDATION}
+        />
         <CardPile
           cards={cardPile7()}
-          direction={DIRECTION_RTL}
-          onDragStart={dragStartHandler}
-          onDragEnd={dragEndHandler}
+          direction={DIRECTION_LTR}
+          id={CARD_PILE_7}
+          type={DROPPABLE_TYPE_CARDPILE}
         />
-      </Droppable>
-      <Droppable isDroppable onDrop={dropFoundationHandler(foundationPile4, setFoundationPile4)}>
+        <CardPile
+          cards={cardPile4()}
+          direction={DIRECTION_RTL}
+          id={CARD_PILE_4}
+          type={DROPPABLE_TYPE_CARDPILE}
+        />
         <Foundation
           cards={foundationPile4()}
-          onDragStart={dragStartHandler}
-          onDragEnd={dragEndHandler}
+          id={FOUNDATION_PILE_4}
+          type={DROPPABLE_TYPE_FOUNDATION}
         />
-      </Droppable>
-      <Droppable isDroppable onDrop={dropHandler(cardPile8, setCardPile8)}>
         <CardPile
           cards={cardPile8()}
           direction={DIRECTION_LTR}
-          onDragStart={dragStartHandler}
-          onDragEnd={dragEndHandler}
+          id={CARD_PILE_8}
+          type={DROPPABLE_TYPE_CARDPILE}
         />
-      </Droppable>
-    </div>
+      </div>
+    </DragDropProvider>
   );
 }

--- a/src/features/card-game/Tableau.tsx
+++ b/src/features/card-game/Tableau.tsx
@@ -89,7 +89,12 @@ export function Tableau() {
     const [originalPileGetter, originalPileSetter] = lastCardHash()[draggable.id] || [];
     const [newPileGetter, newPileSetter] = pilesHash()[droppable.id] || [];
 
-    if (!originalPileGetter || !originalPileSetter || !newPileGetter || !newPileSetter) return;
+    if (!originalPileGetter
+      || !originalPileSetter
+      || !newPileGetter
+      || !newPileSetter
+      || originalPileGetter === newPileGetter
+    ) return;
 
     const card = lastCard(originalPileGetter);
     const newPileLastCard = lastCard(newPileGetter);

--- a/src/features/card-game/constants.ts
+++ b/src/features/card-game/constants.ts
@@ -1,0 +1,22 @@
+export const DROPPABLE_TYPE_CARDPILE = 'cardPile';
+export const DROPPABLE_TYPE_FOUNDATION = 'foundation';
+
+export const CARD_PILE_1 = 'pile1';
+export const CARD_PILE_2 = 'pile2';
+export const CARD_PILE_3 = 'pile3';
+export const CARD_PILE_4 = 'pile4';
+export const CARD_PILE_5 = 'pile5';
+export const CARD_PILE_6 = 'pile6';
+export const CARD_PILE_7 = 'pile7';
+export const CARD_PILE_8 = 'pile8';
+export const FOUNDATION_PILE_1 = 'foundation1';
+export const FOUNDATION_PILE_2 = 'foundation2';
+export const FOUNDATION_PILE_3 = 'foundation3';
+export const FOUNDATION_PILE_4 = 'foundation4';
+
+export const FOUNDATION_PILES = [
+  FOUNDATION_PILE_1,
+  FOUNDATION_PILE_2,
+  FOUNDATION_PILE_3,
+  FOUNDATION_PILE_4,
+];

--- a/src/features/card-game/index.ts
+++ b/src/features/card-game/index.ts
@@ -1,4 +1,5 @@
 export * from './Card';
 export * from './CardPile';
+export * from './EmptyCard';
 export * from './Foundation';
 export * from './Tableau';

--- a/src/features/card-game/types.ts
+++ b/src/features/card-game/types.ts
@@ -11,7 +11,6 @@ export interface CardPileProps {
 
 export interface CardProps {
   data: Card;
-  isDraggable: boolean;
   style?: JSX.CSSProperties;
 }
 

--- a/src/features/card-game/types.ts
+++ b/src/features/card-game/types.ts
@@ -1,24 +1,22 @@
 import { JSX } from 'solid-js';
 import { Card } from '@/common/classes/Card';
-import type { Direction, VoidFunction } from '@/common/types';
+import type { Direction } from '@/common/types';
 
 export interface CardPileProps {
   cards: Card[];
   direction: Direction;
-  onDragStart: (arg0: Card) => VoidFunction;
-  onDragEnd: VoidFunction;
+  id: string;
+  type: string;
 }
 
 export interface CardProps {
   data: Card;
   isDraggable: boolean;
-  onDragStart: VoidFunction;
-  onDragEnd: VoidFunction;
   style?: JSX.CSSProperties;
 }
 
 export interface FoundationProps {
   cards: Card[],
-  onDragStart: (arg0: Card) => VoidFunction,
-  onDragEnd: VoidFunction,
+  id: string;
+  type: string;
 }

--- a/src/features/common/Draggable.tsx
+++ b/src/features/common/Draggable.tsx
@@ -1,21 +1,14 @@
 import { JSX } from 'solid-js';
+import { createDraggable } from '@thisbeyond/solid-dnd';
 import type { DraggableProps } from './types';
+import type { Draggable } from '@/common/types';
 
 export function Draggable(props: DraggableProps): JSX.Element {
-  const handleDragStart = () => {
-    props.onDragStart && props.onDragStart();
-  };
-
-  const handleDragEnd = () => {
-    props.onDragEnd && props.onDragEnd();
-  };
+  // @ts-expect-error: Directive used below
+  const draggable = createDraggable(props.id);
 
   return (
-    <div
-      draggable={props.isDraggable}
-      onDragStart={handleDragStart}
-      onDragEnd={handleDragEnd}
-    >
+    <div use:draggable class={props.class}>
       {props.children}
     </div>
   );

--- a/src/features/common/Droppable.tsx
+++ b/src/features/common/Droppable.tsx
@@ -1,25 +1,14 @@
 import { JSX } from 'solid-js';
-import { DroppableProps } from './types';
+import { createDroppable } from '@thisbeyond/solid-dnd';
+import type { DroppableProps } from './types';
+import type { Droppable } from '@/common/types';
 
 export function Droppable(props: DroppableProps): JSX.Element {
-  const handleDrop = (event: DragEvent) => {
-    event.preventDefault();
-    props.isDroppable && props.onDrop && props.onDrop();
-  };
-
-  const handleDragOver = (event: DragEvent) => {
-    event.preventDefault();
-    props.isDroppable && props.onDragOver && props.onDragOver();
-  };
-
-  const handleDragEnd = (event: DragEvent) => { event.preventDefault() };
+  // @ts-expect-error: Directive used below
+  const droppable = createDroppable(props.id);
 
   return (
-    <div
-      onDrop={handleDrop}
-      onDragOver={handleDragOver}
-      onDragEnd={handleDragEnd}
-    >
+    <div use:droppable>
       {props.children}
     </div>
   );

--- a/src/features/common/types.ts
+++ b/src/features/common/types.ts
@@ -1,16 +1,13 @@
 import { JSX } from 'solid-js';
-import { VoidFunction } from '@/common/types';
 
 export interface DraggableProps {
+  class?: string;
   children: JSX.Element;
-  isDraggable: boolean;
-  onDragStart?: VoidFunction;
-  onDragEnd?: VoidFunction;
+  id: string;
 }
 
 export interface DroppableProps {
   children: JSX.Element;
-  isDroppable?: boolean;
-  onDragOver?: VoidFunction;
-  onDrop?: VoidFunction;
+  id: string;
+  type: string;
 }


### PR DESCRIPTION
Through some research I've learned some of the limitations of native HTML5 dragged items in that items that are dragged are placed in a temporary container and then moved. However, the problem is that you are unable to style that container which resulted in cards that had a while background despite having rounded corners.

The common way to get around that are to `position` the original element relative to it's starting place based on the event provided by the `onDrag` event. This led to some weird priority issues where my cards couldn't be positioned as I wanted because they were already `position`ed to stack neatly within the `CardPile`.

With some fun nights trying to figure out how to do this natively with little luck, I decided to instead implement `@thisbeyond/solid-dnd` drag and drop SolidJS package which mostly alleviated my problems even if I had to refactor the drag and drop events themselves. While SolidJS directives have some interesting side-effects, it was nice to learn and pick through as it seems other libs use much of the same structure.

Using the lib also conveniently addresses the issue of having to make the original card hidden or needing to move with the cursor. So two birds with one scone, or something like that.

Resolves #2 