### PR TITLE
Feature: Create Double Click Event

### DIFF
--- a/src/common/constants/index.ts
+++ b/src/common/constants/index.ts
@@ -1,2 +1,7 @@
 export const DIRECTION_LTR = 'ltr';
 export const DIRECTION_RTL = 'rtl';
+
+export const SUIT_DIAMONDS = 'diamonds';
+export const SUIT_HEARTS = 'hearts';
+export const SUIT_SPADES = 'spades';
+export const SUIT_CLUBS = 'clubs';

--- a/src/features/card-game/Card.tsx
+++ b/src/features/card-game/Card.tsx
@@ -7,8 +7,17 @@ export function Card(props: CardProps): JSX.Element {
   // @ts-expect-error: Directive used below
   const draggable = createDraggable(props.data.id);
 
+  const doubleClickHandler = () => {
+    props.onDoubleClick && props.onDoubleClick();
+  };
+
   return (
-    <div use:draggable class="card-game-card" style={props.style}>
+    <div
+      use:draggable
+      class="card-game-card"
+      onDblClick={doubleClickHandler}
+      style={props.style}
+    >
       <img
         alt={`${props.data.value} of ${props.data.suit}`}
         class="card-image"

--- a/src/features/card-game/CardPile.tsx
+++ b/src/features/card-game/CardPile.tsx
@@ -1,12 +1,18 @@
 import { For, Show } from 'solid-js';
 import { DIRECTION_LTR, DIRECTION_RTL } from '@/common/constants';
-import { CardPileProps } from './types';
 import { Droppable } from '@/features/common';
+import { Card as CardClass } from '@/common/classes/Card';
 import { Card, EmptyCard } from '.';
+import type { CardPileProps } from './types';
 import './CardPile.css';
 
 export function CardPile(props: CardPileProps) {
   const getOffset = (index: number) => `${index * 20}px`;
+
+  const doubleClickCardHandler = (card: CardClass) => {
+    if (!props.onDoubleClick) return undefined;
+    return props.onDoubleClick(card);
+  };
 
   return (
     <Droppable id={props.id} type={props.type}>
@@ -27,6 +33,7 @@ export function CardPile(props: CardPileProps) {
             >
               <Card
                 data={item}
+                onDoubleClick={doubleClickCardHandler(item)}
                 style={{
                   left: props.direction === DIRECTION_LTR ? getOffset(index()) : 'auto',
                   right: props.direction === DIRECTION_RTL ? getOffset(index()) : 'auto',

--- a/src/features/card-game/Tableau.tsx
+++ b/src/features/card-game/Tableau.tsx
@@ -10,7 +10,14 @@ import {
 import { DragDropProvider, DragDropSensors, DragEventHandler } from '@thisbeyond/solid-dnd';
 import * as dialog from '@zag-js/dialog';
 import { useMachine, normalizeProps } from '@zag-js/solid';
-import { DIRECTION_LTR, DIRECTION_RTL } from '@/common/constants';
+import {
+  DIRECTION_LTR,
+  DIRECTION_RTL,
+  SUIT_CLUBS,
+  SUIT_DIAMONDS,
+  SUIT_HEARTS,
+  SUIT_SPADES,
+} from '@/common/constants';
 import { Card } from '@/common/classes/Card';
 import { Deck } from '@/common/classes/Deck';
 import { useRedeal } from '@/app/ShouldRedeal';
@@ -59,7 +66,7 @@ export function Tableau() {
   const [moveToPile, setMoveToPile] = createSignal<[Card | null, Setter<Card[]> | null, Setter<Card[]> | null]>([null, null, null]);
 
   const addCard = (nextCard: Card) => (cards: Card[]) => [...cards, nextCard];
-  const lastCard = (cards: Accessor<Card[]>) => cards()[cards().length - 1];
+  const lastCard = (cards: Accessor<Card[]>): Card => cards()[cards().length - 1];
 
   const lastCardHash: () => Record<string, [Accessor<Card[]>, Setter<Card[]>]> = () => ({
     [lastCard(cardPile1)?.id]: [cardPile1, setCardPile1],
@@ -89,6 +96,13 @@ export function Tableau() {
     [FOUNDATION_PILE_2]: [foundationPile2, setFoundationPile2],
     [FOUNDATION_PILE_3]: [foundationPile3, setFoundationPile3],
     [FOUNDATION_PILE_4]: [foundationPile4, setFoundationPile4],
+  });
+
+  const suitHash: () => Record<string, [Accessor<Card[]>, Setter<Card[]>]> = () => ({
+    [SUIT_HEARTS]: [foundationPile1, setFoundationPile1],
+    [SUIT_DIAMONDS]: [foundationPile2, setFoundationPile2],
+    [SUIT_CLUBS]: [foundationPile3, setFoundationPile3],
+    [SUIT_SPADES]: [foundationPile4, setFoundationPile4],
   });
 
   const [isFoundation1Animating, setIsFoundation1Animating] = createSignal<boolean>(false);
@@ -229,6 +243,18 @@ export function Tableau() {
     draggable.node.classList.add('dragging');
   };
 
+  const doubleClickCardHandler = (card: Card) => () => {
+    const [, currentPileSetter] = lastCardHash()[card.id] || [];
+    const [foundationPile, foundationPileSetter] = suitHash()[card.suit] || [];
+
+    if (!foundationPile || !foundationPileSetter || !currentPileSetter) return;
+
+    const lastFoundationCard = lastCard(foundationPile);
+    if (lastFoundationCard.isOneLesser(card) && lastFoundationCard.isSameSuit(card)) {
+      setMoveToPile([card, foundationPileSetter, currentPileSetter]);
+    }
+  };
+
   const resetTableauxHandler = () => {
     playAgainDialog()?.close();
     initTableaux();
@@ -293,6 +319,7 @@ export function Tableau() {
             cards={cardPile1()}
             direction={DIRECTION_RTL}
             id={CARD_PILE_1}
+            onDoubleClick={doubleClickCardHandler}
             type={DROPPABLE_TYPE_CARDPILE}
           />
           <Foundation
@@ -305,12 +332,14 @@ export function Tableau() {
             cards={cardPile5()}
             direction={DIRECTION_LTR}
             id={CARD_PILE_5}
+            onDoubleClick={doubleClickCardHandler}
             type={DROPPABLE_TYPE_CARDPILE}
           />
           <CardPile
             cards={cardPile2()}
             direction={DIRECTION_RTL}
             id={CARD_PILE_2}
+            onDoubleClick={doubleClickCardHandler}
             type={DROPPABLE_TYPE_CARDPILE}
           />
           <Foundation
@@ -323,12 +352,14 @@ export function Tableau() {
             cards={cardPile6()}
             direction={DIRECTION_LTR}
             id={CARD_PILE_6}
+            onDoubleClick={doubleClickCardHandler}
             type={DROPPABLE_TYPE_CARDPILE}
           />
           <CardPile
             cards={cardPile3()}
             direction={DIRECTION_RTL}
             id={CARD_PILE_3}
+            onDoubleClick={doubleClickCardHandler}
             type={DROPPABLE_TYPE_CARDPILE}
           />
           <Foundation
@@ -341,12 +372,14 @@ export function Tableau() {
             cards={cardPile7()}
             direction={DIRECTION_LTR}
             id={CARD_PILE_7}
+            onDoubleClick={doubleClickCardHandler}
             type={DROPPABLE_TYPE_CARDPILE}
           />
           <CardPile
             cards={cardPile4()}
             direction={DIRECTION_RTL}
             id={CARD_PILE_4}
+            onDoubleClick={doubleClickCardHandler}
             type={DROPPABLE_TYPE_CARDPILE}
           />
           <Foundation
@@ -359,6 +392,7 @@ export function Tableau() {
             cards={cardPile8()}
             direction={DIRECTION_LTR}
             id={CARD_PILE_8}
+            onDoubleClick={doubleClickCardHandler}
             type={DROPPABLE_TYPE_CARDPILE}
           />
         </div>

--- a/src/features/card-game/types.ts
+++ b/src/features/card-game/types.ts
@@ -7,11 +7,13 @@ export interface CardPileProps {
   cards: Card[];
   direction: Direction;
   id: string;
+  onDoubleClick?: (arg0: Card) => VoidFunction;
   type: string;
 }
 
 export interface CardProps {
   data: Card;
+  onDoubleClick?: VoidFunction;
   style?: JSX.CSSProperties;
 }
 


### PR DESCRIPTION
I didn't know this was a feature with regular solitaire, but I learned that some games would allow the user to double click a card from a pile in order to move it to the foundations. Seeing my partner use this technique, or wishing it was there, I decided to add it in.

Now double clicking on the last card in a card pile, provided it can be added directly on to the Foundation, will move the card there.

I will be adding this to the eventual gear menu later so that the option is shown as automatically enabled. For now it will be a "hidden" feature.

Resolves #11 