### PR TITLE
Feature: Add Tooltip for EmptyCards

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@zag-js/dialog": "^0.34.0",
         "@zag-js/popover": "^0.34.0",
         "@zag-js/solid": "^0.34.0",
+        "@zag-js/tooltip": "^0.34.0",
         "solid-js": "^1.8.7"
       },
       "devDependencies": {
@@ -1984,6 +1985,20 @@
       "integrity": "sha512-ZddPFdb7Txr6n35ImUAOWVfc5NexGdOxvV+Crnj66HrAs1tIP2ZrDiUodZuy/O+iBVE+NR64HcAfiZURMirJ9A==",
       "dependencies": {
         "@zag-js/dom-query": "0.34.0"
+      }
+    },
+    "node_modules/@zag-js/tooltip": {
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/tooltip/-/tooltip-0.34.0.tgz",
+      "integrity": "sha512-p7g20zMV7WcXssShdZdWaSjiaO+JJEynEr++lVNpzNmdY0nr8zP5TjqRQhKzx0LNArILTNbX0SkafoJpTiC1AA==",
+      "dependencies": {
+        "@zag-js/anatomy": "0.34.0",
+        "@zag-js/core": "0.34.0",
+        "@zag-js/dom-event": "0.34.0",
+        "@zag-js/dom-query": "0.34.0",
+        "@zag-js/popper": "0.34.0",
+        "@zag-js/types": "0.34.0",
+        "@zag-js/utils": "0.34.0"
       }
     },
     "node_modules/@zag-js/types": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@zag-js/dialog": "^0.34.0",
     "@zag-js/popover": "^0.34.0",
     "@zag-js/solid": "^0.34.0",
+    "@zag-js/tooltip": "^0.34.0",
     "solid-js": "^1.8.7"
   },
   "devDependencies": {

--- a/src/app/zag.css
+++ b/src/app/zag.css
@@ -88,3 +88,11 @@
     }
   }
 }
+
+[data-scope="tooltip"] {
+  [data-part="content"] {
+    z-index: 1;
+    border: 1px solid black;
+    padding: 6px;
+  }
+}

--- a/src/assets/icons/clubs.svg
+++ b/src/assets/icons/clubs.svg
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="240"
+   height="260"
+   id="svg2"
+   sodipodi:version="0.32"
+   inkscape:version="0.46"
+   version="1.0"
+   sodipodi:docbase="C:\Documents and Settings\Flanker\Desktop\Temporanei\SVG\Piacentine SVG"
+   sodipodi:docname="SuitClubs.svg"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.98994949"
+     inkscape:cx="184.52216"
+     inkscape:cy="135.80548"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="false"
+     width="240px"
+     height="260px"
+     inkscape:window-width="1280"
+     inkscape:window-height="885"
+     inkscape:window-x="22"
+     inkscape:window-y="0"
+     showgrid="false" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Livello 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-288.15635,-348.0625)">
+    <path
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:3.9994173;stroke-dasharray:none;stroke-opacity:1"
+       d="M 408.15639,368.79905 C 379.39014,368.79906 356.02769,392.16149 356.02769,420.92775 C 356.02772,441.41782 367.85955,459.15021 385.07688,467.65086 C 390.25818,470.20901 384.60395,476.8313 380.79941,472.53939 C 371.24485,461.76088 357.31062,454.95947 341.78513,454.95947 C 313.01888,454.95946 289.65635,478.32191 289.65635,507.08817 C 289.65635,535.85443 313.01903,559.16987 341.78513,559.16987 C 370.33092,559.16987 393.61306,536.20881 393.91384,507.74624 C 393.96721,502.69704 401.7167,502.17398 401.7167,508.96838 C 401.7167,519.66771 391.43054,576.49172 385.92297,587.32595 C 391.9345,585.8101 401.95338,584.55266 408.15639,584.55265 C 414.35941,584.55266 424.37829,585.8101 430.38982,587.32595 C 424.88225,576.49172 414.59609,519.66771 414.59609,508.96838 C 414.59609,502.17398 422.34558,502.69704 422.39895,507.74624 C 422.69973,536.20881 445.98193,559.16987 474.52765,559.16987 C 503.29392,559.16987 526.65632,535.85443 526.65635,507.08817 C 526.65635,478.32191 503.29392,454.95946 474.52765,454.95947 C 459.00226,454.95947 445.06794,461.76088 435.51338,472.53939 C 431.70884,476.8313 426.05461,470.20901 431.23591,467.65086 C 448.45324,459.15021 460.28507,441.41782 460.28509,420.92775 C 460.28509,392.16149 436.92265,368.79906 408.15639,368.79905 z"
+       id="path3211" />
+  </g>
+</svg>

--- a/src/assets/icons/diamonds.svg
+++ b/src/assets/icons/diamonds.svg
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="240"
+   height="260"
+   id="svg2"
+   sodipodi:version="0.32"
+   inkscape:version="0.46"
+   version="1.0"
+   sodipodi:docbase="C:\Documents and Settings\Flanker\Desktop\Temporanei\SVG\Piacentine SVG"
+   sodipodi:docname="SuitDiamonds.svg"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.77596155"
+     inkscape:cx="141.75202"
+     inkscape:cy="-9.3595536"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="false"
+     width="240px"
+     height="260px"
+     inkscape:window-width="1280"
+     inkscape:window-height="885"
+     inkscape:window-x="132"
+     inkscape:window-y="0"
+     showgrid="false" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Livello 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-288.15635,-348.0625)">
+    <path
+       id="path3200"
+       d="M 408.15635,352.45099 C 385.76859,400.21284 352.76072,442.26342 308.15635,478.0625 C 352.76072,513.86156 385.76859,555.91215 408.15635,603.674 C 430.54411,555.91215 463.55198,513.86156 508.15635,478.0625 C 463.55198,442.26342 430.54411,400.21284 408.15635,352.45099 z"
+       style="fill:#dd1a1e;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:3.9994173;stroke-dasharray:none;stroke-opacity:1" />
+  </g>
+</svg>

--- a/src/assets/icons/hearts.svg
+++ b/src/assets/icons/hearts.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 15.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="72px" height="72px" viewBox="0 0 72 72" enable-background="new 0 0 72 72" xml:space="preserve">
+<path fill="#ED2224" d="M35.84,21.358c-11.368-11.92-27-6-27,9c0,14.684,14.842,18.631,21.158,24.947
+	c0.947,0.947,3.711,3.474,5.921,7.895c2.289-4.421,4.974-6.947,5.921-7.895c6-6.316,21-10.264,21-24.632
+	C62.84,15.358,47.051,9.438,35.84,21.358z"/>
+</svg>

--- a/src/assets/icons/index.ts
+++ b/src/assets/icons/index.ts
@@ -1,9 +1,17 @@
 import helpCircle from './help-circle.svg';
 import close from './x.svg';
 import refresh from './rotate-cw.svg';
+import spades from './spades.svg';
+import clubs from './clubs.svg';
+import diamonds from './diamonds.svg';
+import hearts from './hearts.svg';
 
 export {
   close,
   helpCircle,
   refresh,
+  spades,
+  hearts,
+  diamonds,
+  clubs,
 };

--- a/src/assets/icons/spades.svg
+++ b/src/assets/icons/spades.svg
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="240"
+   height="260"
+   id="svg2"
+   sodipodi:version="0.32"
+   inkscape:version="0.46"
+   version="1.0"
+   sodipodi:docbase="C:\Documents and Settings\Flanker\Desktop\Temporanei\SVG\Piacentine SVG"
+   sodipodi:docname="SuitSpades.svg"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.6115385"
+     inkscape:cx="120"
+     inkscape:cy="130"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="false"
+     width="240px"
+     height="260px"
+     inkscape:window-width="1280"
+     inkscape:window-height="885"
+     inkscape:window-x="132"
+     inkscape:window-y="0"
+     showgrid="false" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Livello 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-300.375,-343.5)">
+    <path
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:3, 3;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 420.37498,349.55102 C 360.40052,390.08152 320.37505,467.57634 320.375,514.71623 C 320.375,539.21657 340.29885,560.81235 366.92151,560.81235 C 388.48053,560.81235 406.86151,541.23743 406.86146,514.26579 C 406.86146,510.20054 408.9958,508.40994 410.76536,508.40994 C 413.08604,508.40994 415.42002,511.71285 415.42002,518.01954 C 415.42002,533.65083 407.57185,573.31705 396.95155,597.44898 C 403.08128,595.63666 411.25603,593.8454 420.37498,593.8454 C 429.49402,593.8454 437.81882,595.63666 443.94856,597.44898 C 433.32825,573.31705 425.48008,533.65083 425.48008,518.01954 C 425.48008,511.71285 427.81406,508.40994 430.13474,508.40994 C 431.9043,508.40994 433.88849,510.20054 433.88849,514.26579 C 433.88854,541.23743 452.41957,560.81235 473.97859,560.81235 C 500.60125,560.81235 520.375,539.21657 520.375,514.71623 C 520.37505,467.57634 480.34948,390.08152 420.37498,349.55102 z"
+       id="path2401" />
+  </g>
+</svg>

--- a/src/common/classes/Card.ts
+++ b/src/common/classes/Card.ts
@@ -1,21 +1,56 @@
 import { CardValue, Suit } from '@/common/types';
 import cardImages from '@/assets/cards';
+import { clubs, diamonds, hearts, spades } from '@/assets/icons';
 
 export class Card {
   id: string;
   suit: Suit;
   value: CardValue;
+  shortValue: string;
   image: string;
+  suitImage: string;
 
   constructor(suit: Suit, value: CardValue) {
     this.id = `${suit}${value}`;
     this.suit = suit;
     this.value = value;
+    this.shortValue = this.getShortValue(value);
     this.image = this.getImage(suit, value);
+    this.suitImage = this.getSuitImage(suit);
   }
 
   private getImage(suit: Suit, value: string): string {
     return cardImages[suit + value];
+  }
+
+  private getSuitImage(suit: Suit): string {
+    switch (suit) {
+      case 'clubs':
+        return clubs;
+      case 'spades':
+        return spades;
+      case 'hearts':
+        return hearts;
+      case 'diamonds':
+        return diamonds;
+    }
+  }
+
+  private getShortValue(value: CardValue): string {
+    switch (value) {
+      case '10':
+        return '10';
+      case 'Jack':
+        return 'J';
+      case 'Queen':
+        return 'Q';
+      case 'King':
+        return 'K';
+      case 'Ace':
+        return 'A';
+      default:
+        return value;
+    }
   }
 
   isOneLesser(card: Card) {

--- a/src/features/card-game/Card.css
+++ b/src/features/card-game/Card.css
@@ -2,12 +2,26 @@
   position: absolute;
   width: 100px;
   height: 150px;
+
+  &.dragging {
+    z-index: 1;
+  }
+
+  .card-image {
+    width: 100%;
+  }
 }
 
-.card-game-card.dragging {
-  z-index: 1;
+.card-game-card-tooltip {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+
+  .suit {
+    height: 16px;
+  }
 }
 
-.card-game-card .card-image {
-  width: 100%;
-}
+
+

--- a/src/features/card-game/CardPile.tsx
+++ b/src/features/card-game/CardPile.tsx
@@ -28,6 +28,7 @@ export function CardPile(props: CardPileProps) {
                     left: props.direction === DIRECTION_LTR ? getOffset(index()) : 'auto',
                     right: props.direction === DIRECTION_RTL ? getOffset(index()) : 'auto',
                   }}
+                  direction={props.direction}
                 />
               )}
             >

--- a/src/features/card-game/EmptyCard.tsx
+++ b/src/features/card-game/EmptyCard.tsx
@@ -1,16 +1,42 @@
-import { JSX } from 'solid-js';
+import { createMemo, createUniqueId, JSX, Show } from 'solid-js';
+import * as tooltip from '@zag-js/tooltip';
+import { normalizeProps, useMachine } from '@zag-js/solid';
+import { DIRECTION_LTR } from '@/common/constants';
 import type { CardProps } from './types';
 import './Card.css';
 
 export function EmptyCard(props: CardProps): JSX.Element {
+  const [state, send] = useMachine(tooltip.machine({
+    id: createUniqueId(),
+    positioning: {
+      placement: props.direction === DIRECTION_LTR ? 'left' : 'right',
+    },
+  }));
+
+  const api = createMemo(() => tooltip.connect(state, send, normalizeProps));
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const divProps: any = api().triggerProps;
+
   return (
-    <div class="card-game-card" style={props.style}>
-      <img
-        alt={`${props.data.value} of ${props.data.suit}`}
-        class="card-image"
-        src={props.data.image}
-        draggable="false"
-      />
-    </div>
+    <>
+      <div {...divProps} class="card-game-card" style={props.style}>
+        <img
+          alt={`${props.data.value} of ${props.data.suit}`}
+          class="card-image"
+          src={props.data.image}
+          draggable="false"
+        />
+      </div>
+      <Show when={api().isOpen}>
+        <div {...api().positionerProps}>
+          <div {...api().contentProps}>
+            <div class="card-game-card-tooltip">
+              <img class="suit" src={props.data.suitImage} alt={props.data.suit} />
+              {props.data.shortValue}
+            </div>
+          </div>
+        </div>
+      </Show>
+    </>
   );
 }

--- a/src/features/card-game/types.ts
+++ b/src/features/card-game/types.ts
@@ -15,6 +15,7 @@ export interface CardProps {
   data: Card;
   onDoubleClick?: VoidFunction;
   style?: JSX.CSSProperties;
+  direction?: string;
 }
 
 export interface FoundationProps {


### PR DESCRIPTION
Cards that were on the left side of the tableaux were a bit hard to see when they were upside down, especially cards that were either 6 or 9. In order to help with readability of cards in the tableaux, I added a tooltip for the empty cards that appears on hovering.

The tooltip will either appear to the right or left of the card depending on what side of the tableaux it is on. It will also not appear for the top most cards as those are supposed to be legible already.

Resolves #19 