### PR TITLE
Feature: Game Timer

### DIFF
--- a/src/app/zag.css
+++ b/src/app/zag.css
@@ -92,7 +92,6 @@
 [data-scope="tooltip"] {
   [data-part="content"] {
     z-index: 1;
-    border: 1px solid black;
     padding: 6px;
   }
 }

--- a/src/assets/icons/diamonds.svg
+++ b/src/assets/icons/diamonds.svg
@@ -58,6 +58,6 @@
     <path
        id="path3200"
        d="M 408.15635,352.45099 C 385.76859,400.21284 352.76072,442.26342 308.15635,478.0625 C 352.76072,513.86156 385.76859,555.91215 408.15635,603.674 C 430.54411,555.91215 463.55198,513.86156 508.15635,478.0625 C 463.55198,442.26342 430.54411,400.21284 408.15635,352.45099 z"
-       style="fill:#dd1a1e;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:3.9994173;stroke-dasharray:none;stroke-opacity:1" />
+       style="fill:#ff5555;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:3.9994173;stroke-dasharray:none;stroke-opacity:1" />
   </g>
 </svg>

--- a/src/assets/icons/hearts.svg
+++ b/src/assets/icons/hearts.svg
@@ -3,7 +3,7 @@
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 width="72px" height="72px" viewBox="0 0 72 72" enable-background="new 0 0 72 72" xml:space="preserve">
-<path fill="#ED2224" d="M35.84,21.358c-11.368-11.92-27-6-27,9c0,14.684,14.842,18.631,21.158,24.947
+<path fill="#ff5555" d="M35.84,21.358c-11.368-11.92-27-6-27,9c0,14.684,14.842,18.631,21.158,24.947
 	c0.947,0.947,3.711,3.474,5.921,7.895c2.289-4.421,4.974-6.947,5.921-7.895c6-6.316,21-10.264,21-24.632
 	C62.84,15.358,47.051,9.438,35.84,21.358z"/>
 </svg>

--- a/src/common/utils/formatToTwoNumbers.ts
+++ b/src/common/utils/formatToTwoNumbers.ts
@@ -1,0 +1,6 @@
+export function formatToTwoNumbers(integer: number) {
+  return integer.toLocaleString('en-US', {
+    minimumIntegerDigits: 2,
+    useGrouping: false,
+  });
+}

--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './createStorageSignal';
+export * from './formatToTwoNumbers';

--- a/src/features/card-game/PlayAgainModal.css
+++ b/src/features/card-game/PlayAgainModal.css
@@ -3,6 +3,14 @@
 
   .statistics {
     text-align: center;
+
+    &:first-of-type {
+      margin-bottom: 0;
+    }
+
+    &:last-of-type {
+      margin-top: 0;
+    }
   }
 
   .button-container {

--- a/src/features/card-game/PlayAgainModal.tsx
+++ b/src/features/card-game/PlayAgainModal.tsx
@@ -3,13 +3,17 @@ import { Modal } from '@/features/common';
 import { useStatistics } from '@/features/settings';
 import { isSettingEnabled } from '@/features/settings/utils';
 import { SETTING_MOVE_COUNT } from '@/features/settings/constants';
+import { formatToTwoNumbers } from '@/common/utils';
 import type { PlayAgainModalProps } from './types';
 import './PlayAgainModal.css';
 
 export function PlayAgainModal(props: PlayAgainModalProps) {
-  const { moveCount } = useStatistics();
+  const { moveCount, gameTimer } = useStatistics();
 
   const isMoveCountEnabled = isSettingEnabled(SETTING_MOVE_COUNT);
+
+  const minutes = () => Math.floor(gameTimer() / 60);
+  const seconds = () => formatToTwoNumbers(gameTimer() - minutes() * 60);
 
   const clickNoHandler = () => {
     props.machine().close();
@@ -26,6 +30,9 @@ export function PlayAgainModal(props: PlayAgainModalProps) {
         <Show when={isMoveCountEnabled()}>
           <p {...props.machine().descriptionProps} class="statistics">
             Total Moves: <b>{moveCount()}</b>
+          </p>
+          <p {...props.machine().descriptionProps} class="statistics">
+            Total Game Time: <b>{minutes()}:{seconds()}</b>
           </p>
         </Show>
         <div class="button-container">

--- a/src/features/card-game/Tableau.tsx
+++ b/src/features/card-game/Tableau.tsx
@@ -47,8 +47,21 @@ import {
 import './Tableau.css';
 
 export function Tableau() {
-  const { shouldRedeal, shouldUndo, clearRedeal, clearUndo } = useDealer();
-  const { addMove, resetMoveCount } = useStatistics();
+  const {
+    shouldRedeal,
+    shouldUndo,
+    clearRedeal,
+    clearUndo,
+  } = useDealer();
+
+  const {
+    addMove,
+    gameTimer,
+    resetGameTimer,
+    resetMoveCount,
+    startGameTimer,
+    stopGameTimer,
+  } = useStatistics();
 
   const isDoubleClickEnabled = isSettingEnabled(SETTING_DOUBLECLICK_CARD);
   const isBesiegedCastleEnabled = isSettingEnabled(SETTING_BESIEGED_CASTLE);
@@ -213,6 +226,9 @@ export function Tableau() {
     setCardPile6(tempPile6);
     setCardPile7(tempPile7);
     setCardPile8(tempPile8);
+
+    resetMoveCount();
+    resetGameTimer();
   };
 
   const moveCard = (
@@ -226,6 +242,7 @@ export function Tableau() {
       from(cards => cards.slice(0, cards.length - 1));
       recordHistory && setPreviousMoves(previousMoves => [...previousMoves, [droppedCard, to, from]]);
       addMove();
+      gameTimer() === 0 && startGameTimer();
     }
   };
 
@@ -290,7 +307,6 @@ export function Tableau() {
     if (shouldRedeal()) {
       initTableaux();
       clearRedeal();
-      resetMoveCount();
     }
   });
 
@@ -323,6 +339,8 @@ export function Tableau() {
       cardPile7().length === 0 &&
       cardPile8().length === 0
     ) {
+      stopGameTimer();
+
       areFoundationsAnimating().forEach((setter, index) => {
         setTimeout(() => {
           setter(true);

--- a/src/features/settings/Statistics.tsx
+++ b/src/features/settings/Statistics.tsx
@@ -1,24 +1,48 @@
-import { createContext, createSignal, useContext } from 'solid-js';
+import { createContext, createSignal, onCleanup, useContext } from 'solid-js';
 import type { StatisticsProvider, StatisticsProviderProps } from './types';
 
 const StatisticsContext = createContext<StatisticsProvider>({
   moveCount: () => 0,
+  gameTimer: () => 0,
   addMove: () => {},
+  resetGameTimer: () => {},
   resetMoveCount: () => {},
+  startGameTimer: () => {},
+  stopGameTimer: () => {},
 });
 
 export function StatisticsProvider(props: StatisticsProviderProps) {
   const [moveCount, setMoveCount] = createSignal<number>(0);
+  const [gameTimer, setGameTimer] = createSignal<number>(0);
+
+  let intervalTimer: null | ReturnType<typeof setInterval> = null;
 
   const statisticsManager = {
     moveCount,
+    gameTimer,
     addMove: () => {
       setMoveCount(prevMoveCount => prevMoveCount + 1);
     },
     resetMoveCount: () => {
       setMoveCount(0);
     },
+    resetGameTimer: () => {
+      setGameTimer(0);
+      if (intervalTimer !== null) clearInterval(intervalTimer);
+    },
+    startGameTimer: () => {
+      intervalTimer = setInterval(() => {
+        setGameTimer(prevTime => prevTime + 1);
+      }, 1000);
+    },
+    stopGameTimer: () => {
+      if (intervalTimer !== null) clearInterval(intervalTimer);
+    },
   };
+
+  onCleanup(() => {
+    if (intervalTimer !== null) clearInterval(intervalTimer);
+  });
 
   return (
     <StatisticsContext.Provider value={statisticsManager}>

--- a/src/features/settings/constants.ts
+++ b/src/features/settings/constants.ts
@@ -11,8 +11,8 @@ export const DEFAULT_SETTINGS: Record<string, boolean> = {
   [SETTING_BESIEGED_CASTLE]: false,
   [SETTING_DOUBLECLICK_CARD]: true,
   [SETTING_FOUNDATION_MOVE]: true,
-  [SETTING_MOVE_COUNT]: false,
   [SETTING_UNDO]: false,
+  [SETTING_MOVE_COUNT]: false,
   [SETTING_DARK_MODE]: false,
 };
 
@@ -29,13 +29,13 @@ export const SETTING_DESCRIPTORS: Record<string, Partial<Setting>> = {
     name: 'Move From Foundations',
     description: 'Allow movement from foundations to outside card piles',
   },
-  [SETTING_MOVE_COUNT]: {
-    name: 'Move Count',
-    description: 'Show a total count of how many moves made during the game',
-  },
   [SETTING_UNDO]: {
     name: 'Undos',
     description: 'Show an undo button that will "undo" the last move',
+  },
+  [SETTING_MOVE_COUNT]: {
+    name: 'Statistics',
+    description: 'Show a total move counter and a play timer',
   },
   [SETTING_DARK_MODE]: {
     name: 'Dark Mode',

--- a/src/features/settings/types.ts
+++ b/src/features/settings/types.ts
@@ -24,8 +24,12 @@ export interface StatisticsProviderProps {
 
 export interface StatisticsProvider {
   moveCount: Accessor<number> | (() => number);
+  gameTimer: Accessor<number> | (() => number);
   addMove: VoidFunction;
+  resetGameTimer: VoidFunction;
   resetMoveCount: VoidFunction;
+  startGameTimer: VoidFunction;
+  stopGameTimer: VoidFunction;
 }
 
 export interface DealerProviderProps {

--- a/src/features/toolbar/StatisticsDisplay.css
+++ b/src/features/toolbar/StatisticsDisplay.css
@@ -1,6 +1,10 @@
 .statistics-diplay {
-  .move-count {
+  display: flex;
+  align-items: flex-start;
+  flex-direction: column;
+
+  .details {
     color: white;
-    font-size: 14px;
+    font-size: 15px;
   }
 }

--- a/src/features/toolbar/StatisticsDisplay.tsx
+++ b/src/features/toolbar/StatisticsDisplay.tsx
@@ -1,15 +1,20 @@
 import { Show } from 'solid-js';
 import { useStatistics } from '@/features/settings';
+import { formatToTwoNumbers } from '@/common/utils';
 import type { StatisticsDisplayProps } from './types';
 import './StatisticsDisplay.css';
 
 export function StatisticsDisplay(props: StatisticsDisplayProps) {
-  const { moveCount } = useStatistics();
+  const { moveCount, gameTimer } = useStatistics();
+
+  const minutes = () => Math.floor(gameTimer() / 60);
+  const seconds = () => formatToTwoNumbers(gameTimer() - minutes() * 60);
 
   return (
     <Show when={props.isVisible}>
       <div class="statistics-diplay">
-        <div class="move-count">Total Moves: {moveCount()}</div>
+        <div class="details">Total Moves: {moveCount()}</div>
+        <div class="details">Play Time: {minutes()}:{seconds()}</div>
       </div>
     </Show>
   );

--- a/src/features/toolbar/Toolbar.css
+++ b/src/features/toolbar/Toolbar.css
@@ -11,5 +11,6 @@
     display: flex;
     gap: 16px;
     justify-content: flex-end;
+    align-items: flex-end;
   }
 }


### PR DESCRIPTION
To support one of the last user facing statistics, there is now a game timer beneath the total move count. The timer will start once the first move is made, and will stop once the game is finished. The timer will appear in the results screen along with the total moves in the `PlayAgainModal`.

This will appear by default for those that originally had the move counter setting on. Relating to that, the move counter setting has also been adjusted to be the general statistics option to encompass more information other than just the move counter.

I also fixed a small visual issue with the hover tooltip which showed a different coloured red diamond and heart than the cards. That has been fixed.

I also fixed the border graphic for the same tooltip which would appear differently in dark mode than the other dialogs/modals.

Resolves #23 