### PR TITLE
Fix Foundation Drag Bug

### DIFF
--- a/src/features/card-game/Card.tsx
+++ b/src/features/card-game/Card.tsx
@@ -1,3 +1,4 @@
+import { createUniqueId } from 'solid-js';
 import type { JSX } from 'solid-js';
 import { createDraggable } from '@thisbeyond/solid-dnd';
 import { SETTING_DARK_MODE } from '@/features/settings/constants';
@@ -9,11 +10,11 @@ export function Card(props: CardProps): JSX.Element {
   const { isModuleEnabled } = useSettings();
 
   // @ts-expect-error: Directive used below
-  const draggable = createDraggable(props.data.id);
+  const draggable = createDraggable(createUniqueId(), props.data);
   const isDarkModeEnabled = isModuleEnabled(SETTING_DARK_MODE);
 
   const doubleClickHandler = () => {
-    props.onDoubleClick && props.onDoubleClick();
+    props.onDoubleClick && props.onDoubleClick(props.data);
   };
 
   return (

--- a/src/features/card-game/CardPile.tsx
+++ b/src/features/card-game/CardPile.tsx
@@ -1,18 +1,12 @@
 import { For, Show } from 'solid-js';
 import { DIRECTION_LTR, DIRECTION_RTL } from '@/common/constants';
 import { Droppable } from '@/features/common';
-import type { Card as CardClass } from '@/common/classes/Card';
 import { Card, EmptyCard } from '.';
 import type { CardPileProps } from './types';
 import './CardPile.css';
 
 export function CardPile(props: CardPileProps) {
   const getOffset = (index: number) => `${index * 26}px`;
-
-  const doubleClickCardHandler = (card: CardClass) => {
-    if (!props.onDoubleClick) return undefined;
-    return props.onDoubleClick(card);
-  };
 
   return (
     <Droppable id={props.id} type={props.type}>
@@ -34,7 +28,7 @@ export function CardPile(props: CardPileProps) {
             >
               <Card
                 data={item}
-                onDoubleClick={doubleClickCardHandler(item)}
+                onDoubleClick={props.onDoubleClick ? props.onDoubleClick : undefined}
                 style={{
                   left: props.direction === DIRECTION_LTR ? getOffset(index()) : 'auto',
                   right: props.direction === DIRECTION_RTL ? getOffset(index()) : 'auto',

--- a/src/features/card-game/Tableau.tsx
+++ b/src/features/card-game/Tableau.tsx
@@ -252,7 +252,7 @@ export function Tableau() {
 
     draggable.node.classList.remove('dragging');
 
-    const [originalPileGetter, originalPileSetter] = lastCardHash()[draggable.id] || [];
+    const [originalPileGetter, originalPileSetter] = lastCardHash()[draggable.data.id] || [];
     const [newPileGetter, newPileSetter] = pilesHash()[droppable.id] || [];
 
     if (!originalPileGetter
@@ -281,7 +281,7 @@ export function Tableau() {
     draggable.node.classList.add('dragging');
   };
 
-  const doubleClickCardHandler = (card: Card) => () => {
+  const doubleClickCardHandler = (card: Card) => {
     if (!isDoubleClickEnabled()) return;
 
     const [, currentPileSetter] = lastCardHash()[card.id] || [];
@@ -290,7 +290,7 @@ export function Tableau() {
     if (!foundationPile || !foundationPileSetter || !currentPileSetter) return;
 
     const lastFoundationCard = lastCard(foundationPile);
-    if (lastFoundationCard.isOneLesser(card) && lastFoundationCard.isSameSuit(card)) {
+    if (lastFoundationCard.isOneLesser(card)) {
       moveCard(card, foundationPileSetter, currentPileSetter);
     }
   };

--- a/src/features/card-game/types.ts
+++ b/src/features/card-game/types.ts
@@ -7,13 +7,13 @@ export interface CardPileProps {
   cards: Card[];
   direction: Direction;
   id: string;
-  onDoubleClick?: (arg0: Card) => VoidFunction;
+  onDoubleClick?: (arg0: Card) => void;
   type: string;
 }
 
 export interface CardProps {
   data: Card;
-  onDoubleClick?: VoidFunction;
+  onDoubleClick?: (argo: Card) => void;
   style?: JSX.CSSProperties;
   direction?: string;
 }

--- a/src/features/settings/Statistics.tsx
+++ b/src/features/settings/Statistics.tsx
@@ -14,8 +14,7 @@ const StatisticsContext = createContext<StatisticsProvider>({
 export function StatisticsProvider(props: StatisticsProviderProps) {
   const [moveCount, setMoveCount] = createSignal<number>(0);
   const [gameTimer, setGameTimer] = createSignal<number>(0);
-
-  let intervalTimer: null | ReturnType<typeof setInterval> = null;
+  const [gameInterval, setGameInterval] = createSignal<null | ReturnType<typeof setInterval>>(null);
 
   const statisticsManager = {
     moveCount,
@@ -28,20 +27,29 @@ export function StatisticsProvider(props: StatisticsProviderProps) {
     },
     resetGameTimer: () => {
       setGameTimer(0);
-      if (intervalTimer !== null) clearInterval(intervalTimer);
+      if (gameInterval() !== null) {
+        clearInterval(gameInterval() || 0);
+        setGameInterval(null);
+      }
     },
     startGameTimer: () => {
-      intervalTimer = setInterval(() => {
+      setGameInterval(setInterval(() => {
         setGameTimer(prevTime => prevTime + 1);
-      }, 1000);
+      }, 1000));
     },
     stopGameTimer: () => {
-      if (intervalTimer !== null) clearInterval(intervalTimer);
+      if (gameInterval() !== null) {
+        clearInterval(gameInterval() || 0);
+        setGameInterval(null);
+      }
     },
   };
 
   onCleanup(() => {
-    if (intervalTimer !== null) clearInterval(intervalTimer);
+    if (gameInterval() !== null) {
+      clearInterval(gameInterval() || 0);
+      setGameInterval(null);
+    }
   });
 
   return (


### PR DESCRIPTION
## What is Broken
Dragging cards away from foundations was not always possible. Specifically if someone moves a card when `Double Click` is enabled to the foundation by double clicking, the user cannot drag it back out, provided `Move From Foundations` is enabled.

## What is Done to Fix the Issue
There seemed to be an issue with the reactive ids that were being given to draggable elements, no doubt as a new element is being created when a new card is placed on the foundation pile (because a new element is created). The reactive id wouldn't be maintained and a draggable couldn't be created because solid-dnd maybe assumed that it existed already?

I used solidjs's uniqueId function to address this issue, allowing all elements to be moved as intended.

## Additional Notes/Updates
Along the way, I also cleaned up the currying function to be more readable. I thought this was the original error source, but that was not the case. So lumping in that change here as well.

There was also a spotty bug happening in which the timer wouldn't end when the game did or if it was reset midway through the game. I changed how the interval was maintained to hopefully remove that issue.

Resolves #32 